### PR TITLE
Update file naming logic in DownloadLocalService to correctly append …

### DIFF
--- a/src/table-download/download-local.service.ts
+++ b/src/table-download/download-local.service.ts
@@ -242,9 +242,9 @@ export class DownloadLocalService {
         (name.endsWith('.pdf') || name.endsWith('.xml'))
       ) {
         const content = entry.getData();
-        const fileName = name.split('/').pop();
+        const fileName = name.endsWith('.pdf') ? '.pdf' : '.xml';
         files.push({
-          name: `luup/${year}/${folderType}/${month}/UNZIP/${doctType}_${day}_${month}_${year}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}`,
+          name: `luup/${year}/${folderType}/${month}/UNZIP/${doctType}_${day}_${month}_${year}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}${fileName}`,
           buffer: content,
         });
       }


### PR DESCRIPTION
…document type extensions

- Modify the file name generation to append the appropriate extension (.pdf or .xml) based on the document type, ensuring accurate file identification in the download process.
- Refactor the existing logic to enhance clarity and maintainability of the file naming convention.