### PR TITLE
Refactor file naming in DownloadLocalService to standardize document …

### DIFF
--- a/src/table-download/download-local.service.ts
+++ b/src/table-download/download-local.service.ts
@@ -244,14 +244,14 @@ export class DownloadLocalService {
         const content = entry.getData();
         const fileName = name.endsWith('.pdf') ? '.pdf' : '.xml';
         files.push({
-          name: `luup/${year}/${folderType}/${month}/UNZIP/${doctType}_${day}_${month}_${year}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}${fileName}`,
+          name: `luup/${year}/${folderType}/${month}/UNZIP/TD${doctType}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}${fileName}`,
           buffer: content,
         });
       }
     }
 
     files.push({
-      name: `luup/${year}/${folderType}/${month}/ZIP/${doctType}_${day}_${month}_${year}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}.zip`,
+      name: `luup/${year}/${folderType}/${month}/ZIP/TD${doctType}_${serieNumber}_${thirdPartyNit}__${thirdPartyName}.zip`,
       buffer: originalZipBuffer,
     });
 


### PR DESCRIPTION
…identifiers

- Update the file naming logic to prepend 'TD' to document type identifiers in both the unzip and zip file paths, ensuring consistency across generated file names.
- Simplify the naming convention by removing unnecessary date components, enhancing clarity and organization of downloaded files.